### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/all-bios-files-md5sum-check.yml
+++ b/.github/workflows/all-bios-files-md5sum-check.yml
@@ -2,6 +2,9 @@ name: ALL BIOS FILES MD5SUM CHECK
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
     all-bios-files-md5sum-check:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/archtaurus/RetroPieBIOS/security/code-scanning/1](https://github.com/archtaurus/RetroPieBIOS/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/all-bios-files-md5sum-check.yml` at the workflow root so it applies to all jobs unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read` (needed for `actions/checkout` and reading repo content)

No other permissions are required based on the shown steps (`npm ci`, `npm test`).

Edit region: near the top of the workflow, after `on: push` and before `jobs:`.  
No imports, methods, or dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
